### PR TITLE
github-actions(deps): update actions to latest versions

### DIFF
--- a/.github/workflows/terraform-destroy.yml
+++ b/.github/workflows/terraform-destroy.yml
@@ -106,7 +106,7 @@ jobs:
       working-directory: infrastructure/terraform
 
     - name: Upload Destroy Plan
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: terraform-destroy-plan-${{ github.event.inputs.environment }}
         path: infrastructure/terraform/destroy-plan
@@ -154,7 +154,7 @@ jobs:
 
     - name: Create Destruction Issue
       if: success()
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       with:
         script: |
           const title = `🗑️ Infrastructure Destroyed - ${{ github.event.inputs.environment }}`;
@@ -198,7 +198,7 @@ jobs:
 
     - name: Notify on Failure
       if: failure()
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       with:
         script: |
           const title = `❌ Infrastructure Destruction Failed - ${{ github.event.inputs.environment }}`;


### PR DESCRIPTION
- Bump actions/upload-artifact from v3 to v4 in terraform-destroy workflow
- Bump actions/github-script from v6 to v7 in terraform-destroy workflow
- Align with PR #23 dependency updates while maintaining all infrastructure improvements
- Ensures consistency across all workflow files

This addresses the Dependabot PR #23 while keeping all workflows up-to-date with the latest action versions for better security and performance.