### PR TITLE
Update python-dotenv to 1.1.1 and requests to 2.32.4 in functions.txt

### DIFF
--- a/requirements/functions.txt
+++ b/requirements/functions.txt
@@ -10,7 +10,7 @@ azure-identity==1.23.1
 
 # HTTP client for function operations
 aiohttp==3.12.14
-requests==2.32.3
+requests==2.32.4
 
 # Configuration
-python-dotenv==1.0.1
+python-dotenv==1.1.1


### PR DESCRIPTION
- Consolidates remaining dependency updates from PRs #16, #19, #22
- Ensures consistency across all requirements files
- python-dotenv: 1.0.1 → 1.1.1 (Python 3.13 support, Windows CLI fixes)
- requests: 2.32.3 → 2.32.4 (CVE-2024-47081 security fix)