### PR TITLE
Update aiohttp to 3.12.15 across all requirements files

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,7 +7,7 @@ azure-core==1.35.0
 azure-common==1.1.28
 
 # HTTP client and utilities
-aiohttp==3.12.14
+aiohttp==3.12.15
 requests==2.32.4
 typing-extensions==4.14.1
 

--- a/requirements/functions.txt
+++ b/requirements/functions.txt
@@ -9,7 +9,7 @@ azure-storage-blob==12.26.0
 azure-identity==1.23.1
 
 # HTTP client for function operations
-aiohttp==3.12.14
+aiohttp==3.12.15
 requests==2.32.4
 
 # Configuration


### PR DESCRIPTION
- Consolidates the final dependency update from PR #11
- aiohttp: 3.12.14 → 3.12.15 (latest patch release)
- Updated in both requirements/base.txt and requirements/functions.txt
- All 5 Dependabot PRs now fully consolidated in develop branch