### PR TITLE
Fix test_get_servicebus_client test by creating manager instance with…

### DIFF
--- a/functions/infrastructure/tests/test_secret_rotation.py
+++ b/functions/infrastructure/tests/test_secret_rotation.py
@@ -69,12 +69,15 @@ class TestSecretRotationManager:
         mock_client = Mock()
         mock_client_class.return_value = mock_client
 
-        with patch.object(self.manager, "_get_credential") as mock_get_cred:
-            mock_credential = Mock()
-            mock_get_cred.return_value = mock_credential
+        with patch.dict(os.environ, {"AZURE_SUBSCRIPTION_ID": "test-sub"}):
+            # Create a new manager instance with the environment variable set
+            manager = SecretRotationManager()
 
-            with patch.dict(os.environ, {"AZURE_SUBSCRIPTION_ID": "test-sub"}):
-                client = self.manager._get_servicebus_client()
+            with patch.object(manager, "_get_credential") as mock_get_cred:
+                mock_credential = Mock()
+                mock_get_cred.return_value = mock_credential
+
+                client = manager._get_servicebus_client()
 
                 mock_imports.assert_called_once()
                 mock_get_cred.assert_called_once()


### PR DESCRIPTION
…in environment context

The test was failing because the SecretRotationManager instance was created in setup_method() before the AZURE_SUBSCRIPTION_ID environment variable was patched. This caused subscription_id to be None, triggering a ValueError in _get_servicebus_client().

The fix creates a new manager instance within the test context where the environment variable is properly set using patch.dict(os.environ). All 13 tests now pass.