### PR TITLE
test: update dependabot config to test PR creation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ updates:
       interval: 'weekly'
       day: 'friday'
       time: '18:00'
-    open-pull-requests-limit: 20
+    open-pull-requests-limit: 25
     assignees:
       - 'stuartshay'
     commit-message:
@@ -24,6 +24,7 @@ updates:
     labels:
       - 'dependencies'
       - 'python'
+      - 'root-level'
 
   # Python dependencies - All Functions (Basic, Advanced, Infrastructure)
   - package-ecosystem: 'pip'
@@ -52,7 +53,7 @@ updates:
       interval: 'weekly'
       day: 'tuesday'
       time: '09:00'
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
     assignees:
       - 'stuartshay'
     commit-message:
@@ -62,6 +63,7 @@ updates:
       - 'dependencies'
       - 'terraform'
       - 'infrastructure'
+      - 'main'
 
   # Terraform providers and modules - Core Infrastructure
   - package-ecosystem: 'terraform'


### PR DESCRIPTION
- Increase open-pull-requests-limit for pip (20 -> 25)
- Increase open-pull-requests-limit for main terraform (5 -> 10)
- Add descriptive labels to help identify update sources
- Testing if permission changes allow PR creation